### PR TITLE
Switch column constants to Strings

### DIFF
--- a/src/main/java/com/google/sps/data/SuperfundSite.java
+++ b/src/main/java/com/google/sps/data/SuperfundSite.java
@@ -5,34 +5,34 @@ package com.google.sps.data;
 public class SuperfundSite {
 
     private String name;
-    private double score;
+    private int siteId;
     private String state;
     private String city;
     private String county;
     private String status;
-    private double lattitude;
+    private double latitude;
     private double longitude;
 
     public SuperfundSite(String name,
-        double score,
+        int siteId,
         String state,
         String city,
         String county,
         String status,
-        double lattitude,
+        double latitude,
         double longitude){
         this.name = name;
-        this.score = score;
+        this.siteId = siteId;
         this.state = state;
         this.city = city;
         this.county = county;
         this.status = status;
-        this.lattitude = lattitude;
+        this.latitude = latitude;
         this.longitude = longitude;
     }
 
     public boolean isValidSite(){
-        return lattitude != 0 && longitude != 0 && !status.equalsIgnoreCase("Not on the NPL");
+        return latitude != 0 && longitude != 0 && !status.equalsIgnoreCase("Not on the NPL");
     }
 
     public boolean equals(Object o){
@@ -46,12 +46,12 @@ public class SuperfundSite {
             state.equals(otherSite.state) &&
             city.equals(otherSite.city) &&
             county.equals(otherSite.county) &&
-            lattitude == otherSite.lattitude &&
+            latitude == otherSite.latitude &&
             longitude == otherSite.longitude;
     }
 
     public String toString(){
-        return name+" in "+city+", "+state+" at "+lattitude +", "+ longitude;
+        return name+" in "+city+", "+state+" at "+latitude +", "+ longitude;
     }
     
 }

--- a/src/main/java/com/google/sps/data/WaterSystem.java
+++ b/src/main/java/com/google/sps/data/WaterSystem.java
@@ -43,16 +43,16 @@ public class WaterSystem {
     public static final String SPLITERATOR = "\",\"";
     public static final int TOTAL_CELL_COUNT = 21;
 
-    private static final int PUBLIC_WATER_SYSTEM_ID_COLUMN = 0;
-    private static final int NAME_COLUMN = 1;
-    private static final int STATE_COLUMN = 3;
-    private static final int CITY_COLUMN = 45;
-    private static final int COUNTY_COLUMN = 46;
-    private static final int POPULATION_COLUMN = 15;
+    private static final String PUBLIC_WATER_SYSTEM_ID_COLUMN = "WATER_SYSTEM.PWSID";
+    private static final String NAME_COLUMN = "WATER_SYSTEM.PWS_NAME";
+    private static final String STATE_COLUMN = "WATER_SYSTEM.PRIMACY_AGENCY_CODE";
+    private static final String CITY_COLUMN = "WATER_SYSTEM.CITIES_SERVED";
+    private static final String COUNTY_COLUMN = "WATER_SYSTEM.COUNTIES_SERVED";
+    private static final String POPULATION_COLUMN = "WATER_SYSTEM.POPULATION_SERVED_COUNT";
 
-    private static final int CONTAMINANT_NAME_COLUMN = 7;
-    private static final int VIOLATION_COLUMN = 18;
-    private static final int ENFORCEMENT_ACTION_COLUMN = 17;
+    private static final String CONTAMINANT_NAME_COLUMN = "SDW_CONTAM_VIOL_ZIP.CNAME";
+    private static final String VIOLATION_COLUMN = "SDW_CONTAM_VIOL_ZIP.ENFDATE";
+    private static final String ENFORCEMENT_ACTION_COLUMN = "SDW_CONTAM_VIOL_ZIP.ENFACTIONNAME";
 
     public static final String WATER_SYSTEM_ENTITY = "WaterSystem";
     public static final String PWSID_PROPERTY = "pwsid";
@@ -151,7 +151,7 @@ public class WaterSystem {
         try {
             URL url = new URL(EPA_VIOLATIONS_LINK + EPA_DATE_PARAMATER + EPA_PWSID_PARAMATER + pwsid + CSV_FORMAT);
             CSVParser csvParser = CSVParser.parse(url, Charset.defaultCharset(),
-                    CSVFormat.EXCEL.withFirstRecordAsHeader());
+                    CSVFormat.EXCEL.withFirstRecordAsHeader().withIgnoreEmptyLines(true));
             for (CSVRecord csvRecord : csvParser.getRecords()) {
                 String contaminantName = csvRecord.get(CONTAMINANT_NAME_COLUMN);
                 contaminantsMap.putIfAbsent(contaminantName, new WaterContaminant(csvRecord));
@@ -191,6 +191,10 @@ public class WaterSystem {
         return systemEntity.getKey();
     }
 
+    public ArrayList<WaterContaminant> getContaminants(){
+        return contaminants;
+    }
+
     public boolean equals(Object o) {
         if (this == o)
             return true;
@@ -222,11 +226,11 @@ public class WaterSystem {
         public static final String HEALTH_PROPERTY = "health";
         public static final String VIOLATIONS_PROPERTY = "violations";
 
-        private static final int CONTAMINANT_CODE_COLUMN = 6;
-        private static final int CONTAMINANT_NAME_COLUMN = 7;
-        private static final int SOURCES_COLUMN = 8;
-        private static final int DEFINITION_COLUMN = 9;
-        private static final int HEALTH_EFFECTS_COLUMN = 10;
+        private static final String CONTAMINANT_CODE_COLUMN = "SDW_CONTAM_VIOL_ZIP.CCODE";
+        private static final String CONTAMINANT_NAME_COLUMN = "SDW_CONTAM_VIOL_ZIP.CNAME";
+        private static final String SOURCES_COLUMN = "SDW_CONTAM_VIOL_ZIP.SOURCES";
+        private static final String DEFINITION_COLUMN = "SDW_CONTAM_VIOL_ZIP.DEFINITION";
+        private static final String HEALTH_EFFECTS_COLUMN = "SDW_CONTAM_VIOL_ZIP.HEALTH_EFFECTS";
 
         private int contaminantCode;
         private String contaminantName;

--- a/src/main/java/com/google/sps/servlets/WaterPollutionServlet.java
+++ b/src/main/java/com/google/sps/servlets/WaterPollutionServlet.java
@@ -57,8 +57,8 @@ public class WaterPollutionServlet extends HttpServlet {
     public static final String EPA_STATE_PARAMETER = "/PRIMACY_AGENCY_CODE/";
     public static final String MIN_DATE = "/ENFDATE/>/01-JAN-14";
     public static final String CSV_FORMAT = "/Excel/";
-    public static final String SPLITERATOR = "\",\"";
-    public static final int TOTAL_CELL_COUNT = 47;
+    // public static final String SPLITERATOR = "\",\"";
+    // public static final int TOTAL_CELL_COUNT = 47;
 
     public static final String WATER_POLLUTION_ENTITY = "WaterPollution";
     public static final String WATERSYSTEMS_PROPERTY = "watersystems";
@@ -70,7 +70,7 @@ public class WaterPollutionServlet extends HttpServlet {
 
     private static final String ZIP_PARAMETER = "zip_code";
 
-    public static final int DEFAULT_SCORE = 100;
+    // public static final int DEFAULT_SCORE = 100;
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 

--- a/src/main/java/com/google/sps/servlets/WaterPollutionServlet.java
+++ b/src/main/java/com/google/sps/servlets/WaterPollutionServlet.java
@@ -57,8 +57,6 @@ public class WaterPollutionServlet extends HttpServlet {
     public static final String EPA_STATE_PARAMETER = "/PRIMACY_AGENCY_CODE/";
     public static final String MIN_DATE = "/ENFDATE/>/01-JAN-14";
     public static final String CSV_FORMAT = "/Excel/";
-    // public static final String SPLITERATOR = "\",\"";
-    // public static final int TOTAL_CELL_COUNT = 47;
 
     public static final String WATER_POLLUTION_ENTITY = "WaterPollution";
     public static final String WATERSYSTEMS_PROPERTY = "watersystems";
@@ -69,8 +67,6 @@ public class WaterPollutionServlet extends HttpServlet {
     private static final String STATE_PARAMATER = "state";
 
     private static final String ZIP_PARAMETER = "zip_code";
-
-    // public static final int DEFAULT_SCORE = 100;
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 

--- a/src/test/java/com/google/sps/SuperfundTest.java
+++ b/src/test/java/com/google/sps/SuperfundTest.java
@@ -42,9 +42,9 @@ public final class SuperfundTest {
         servlet = new SuperfundServlet();
         
         actonSites = new ArrayList<>();
-        actonSites.add(new SuperfundSite("W.R. GRACE & CO., INC. (ACTON PLANT)", SuperfundServlet.DEFAULT_HAZARD_SCORE, "MA", "ACTON", "MIDDLESEX", "Currently on the Final NPL", 42.45055, -71.427781));
-        actonSites.add(new SuperfundSite("W R GRACE DARAMIC PLANT", SuperfundServlet.DEFAULT_HAZARD_SCORE, "MA", "ACTON", "MIDDLESEX", "Not on the NPL", 0, 0));
-        actonSites.add(new SuperfundSite("AGWAY/KRESS PROPERTY", SuperfundServlet.DEFAULT_HAZARD_SCORE, "MA", "ACTON", "MIDDLESEX", "Not on the NPL", 0, 0));
+        actonSites.add(new SuperfundSite("W.R. GRACE & CO., INC. (ACTON PLANT)", 100350, "MA", "ACTON", "MIDDLESEX", "Currently on the Final NPL", 42.45055, -71.427781));
+        actonSites.add(new SuperfundSite("W R GRACE DARAMIC PLANT", 100780, "MA", "ACTON", "MIDDLESEX", "Not on the NPL", 0, 0));
+        actonSites.add(new SuperfundSite("AGWAY/KRESS PROPERTY", 100885, "MA", "ACTON", "MIDDLESEX", "Not on the NPL", 0, 0));
 
     }
 

--- a/src/test/java/com/google/sps/WaterPollutionTest.java
+++ b/src/test/java/com/google/sps/WaterPollutionTest.java
@@ -3,6 +3,8 @@ package com.google.sps;
 import java.io.IOException;
 import java.util.ArrayList;
 
+import javax.jdo.annotations.Order;
+
 import com.google.sps.data.WaterSystem;
 import com.google.sps.servlets.WaterPollutionServlet;
 
@@ -13,6 +15,7 @@ import org.junit.Test;
 public class WaterPollutionTest {
 
     WaterPollutionServlet servlet;
+    ArrayList<WaterSystem> servletSystems;
     
     @Before
     public void setup(){
@@ -21,13 +24,20 @@ public class WaterPollutionTest {
     
     @Test
     public void hometownTest(){
-        ArrayList<WaterSystem> servletSystems = new ArrayList<>();
+        servletSystems = new ArrayList<>();
         try {
             servletSystems = servlet.retrieveSDWViolations("Acton", "MA");
         } catch (IOException e){}
         System.out.println(servletSystems);
         WaterSystem acton = new WaterSystem("MA2002000");
         Assert.assertTrue(servletSystems.contains(acton));
+    }
+
+    @Test
+    public void contaminantsTest(){
+        WaterSystem planetGymnastics = new WaterSystem("MA2002002");
+        planetGymnastics.addViolations();
+        Assert.assertEquals(planetGymnastics.getContaminants().size(), 23);
     }
 
 }


### PR DESCRIPTION
- Use the header strings to get column values instead of integers corresponding to the column
- EPA is giving faulty CSVs which lead to these changes. The CSVParser is throwing IOErrors as a result but I believe this is at the end of the broken CSVs as the tests are still passing
- Switch SuperfundServlet over to Apache CSV Parser from my old basic Scanner setup
- Change Superfund danger score to site ID to be used by frontend to pull up site info
- Fix tests to account for these changes and ensure that the faulty CSVs are not preventing data collection
- Learn how to spell latitude